### PR TITLE
Keep previous catalog entries

### DIFF
--- a/org.oasis.xdita/catalog-dita.xml
+++ b/org.oasis.xdita/catalog-dita.xml
@@ -10,4 +10,13 @@
 
   <public publicId="-//OASIS//ELEMENTS XDITA Highlight Domain//EN" uri="dtd/highlightDomain.mod"/>
 
+  <!-- The following values are deprecated, kept only for compatibility with the previous version -->
+  <public publicId="-//OASIS//DTD LW DITA Topic//EN" uri="dtd/topic.dtd"/>
+  <public publicId="-//OASIS//DTD LW DITA Map//EN" uri="dtd/map.dtd"/>
+
+  <public publicId="-//OASIS//ELEMENTS LW DITA Topic//EN" uri="dtd/topic.mod"/>
+  <public publicId="-//OASIS//ELEMENTS LW DITA Map//EN" uri="dtd/map.mod"/>
+
+  <public publicId="-//OASIS//ELEMENTS LW DITA Highlight Domain//EN" uri="dtd/highlightDomain.mod"/>
+
 </catalog>


### PR DESCRIPTION
Thus files made for previous version of LW-DITA can still be validated if this version is used instead.

If someone updates the plugin and still has files created with the previous version of LW-DITA then the validation will break if the DTDs cannot be found.