### PR TITLE
Add several expected fixes as discussed in call today

### DIFF
--- a/org.oasis.xdita/dtd/highlightDomain.mod
+++ b/org.oasis.xdita/dtd/highlightDomain.mod
@@ -39,6 +39,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Highlight Domain//EN"
 <!ATTLIST b
              %localization;
              %variable-content;
+             outputclass  CDATA          #IMPLIED
              class CDATA "+ topic/ph hi-d/b ">
 
 <!--                    LONG NAME: Italic content  -->
@@ -46,6 +47,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Highlight Domain//EN"
 <!ATTLIST i
              %localization;
              %variable-content;
+             outputclass  CDATA          #IMPLIED
              class CDATA "+ topic/ph hi-d/i ">
 
 <!--                    LONG NAME: Underlined content  -->
@@ -53,6 +55,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Highlight Domain//EN"
 <!ATTLIST u
              %localization;
              %variable-content;
+             outputclass  CDATA          #IMPLIED
              class CDATA "+ topic/ph hi-d/u ">
 
 <!--                    LONG NAME: Superscript content  -->
@@ -60,6 +63,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Highlight Domain//EN"
 <!ATTLIST sup
              %localization;
              %variable-content;
+             outputclass  CDATA          #IMPLIED
              class CDATA "+ topic/ph hi-d/sup ">
 
 <!--                    LONG NAME: Subscript content  -->
@@ -67,4 +71,5 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Highlight Domain//EN"
 <!ATTLIST sub
              %localization;
              %variable-content;
+             outputclass  CDATA          #IMPLIED
              class CDATA "+ topic/ph hi-d/sub ">

--- a/org.oasis.xdita/dtd/highlightDomain.mod
+++ b/org.oasis.xdita/dtd/highlightDomain.mod
@@ -32,6 +32,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Highlight Domain//EN"
 <!--    25 Nov 2014 KJE: Upload files to DITA TC SVN repo          -->
 <!--    16 May 2016  MG: Upload files to GitHub repo               -->
 <!--    11 Jun 2017 KJE: Added headers and update logs             -->
+<!--    14 Jun 2017 RDA: Added @outputclass                        -->
 <!-- ============================================================= -->
 
 <!--                    LONG NAME: Bold content  -->

--- a/org.oasis.xdita/dtd/map.dtd
+++ b/org.oasis.xdita/dtd/map.dtd
@@ -31,6 +31,7 @@ PUBLIC "-//OASIS//DTD XDITA Map//EN"
 <!--    25 Nov 2014 KJE: Upload files to DITA TC SVN repo          -->
 <!--    16 May 2016  MG: Upload files to GitHub repo               -->
 <!--    11 Jun 2017 KJE: Added headers and update logs             -->
+<!--    14 Jun 2017 RDA: Add mapgroup to domains attribute         -->
 <!-- ============================================================= -->
 
 <!-- ============================================================= -->
@@ -54,7 +55,7 @@ PUBLIC "-//OASIS//DTD XDITA Map//EN"
 <!--                    DECLARE USE OF ELEMENT/ATTRIBUTE DOMAINS                 -->
 <!-- ============================================================= -->
 
-<!ENTITY included-domains                         "(hi-d)"                >
+<!ENTITY included-domains                         "(hi-d) (map mapgroup-d)">
 
 <!-- ============================================================= -->
 <!--                    REMOVE ATTRIBUTE/ELEMENT GROUPS                    -->

--- a/org.oasis.xdita/dtd/map.mod
+++ b/org.oasis.xdita/dtd/map.mod
@@ -37,6 +37,9 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!--    13 Jun 2017  CE: Made map ID optional                      -->
 <!--    13 Jun 2017  CE: Added props to <keydef>                   -->
 <!--    14 Jun 2017  CE: Added <image>, <xref> to <ph>; add <alt>  -->
+<!--    14 Jun 2017 RDA: Corrected use of @outputclass,            -->
+<!--                     make localization attributes universal,   -->
+<!--                     add scope/format where needed             -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->
 <!--                    DOMAINS ATTRIBUTE OVERRIDE                 -->
@@ -91,6 +94,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!--                    LONG NAME: Map  -->
 <!ELEMENT map		(topicmeta?, (topicref | keydef)*)  >
 <!ATTLIST map
+             id       ID          #IMPLIED
              xmlns:ditaarch CDATA #FIXED "http://dita.oasis-open.org/architecture/2005/"
 	         ditaarch:DITAArchVersion CDATA "1.3"
              domains    CDATA                    "&xdita-constraint; &included-domains;"
@@ -125,7 +129,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
              %localization;
              name       CDATA                            #IMPLIED
              value      CDATA                            #IMPLIED
-             href       CDATA                            #IMPLIED
+             %reference-content;
              %variable-content;
              outputclass  CDATA          #IMPLIED
              class CDATA "- topic/data ">
@@ -141,7 +145,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!--                    LONG NAME: Image  -->
 <!ELEMENT image             (alt?)        >
 <!ATTLIST image
-             href       CDATA                            #IMPLIED
+             %reference-content;
              height     NMTOKEN                          #IMPLIED
              width      NMTOKEN                          #IMPLIED
              %localization;
@@ -161,9 +165,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!--                    LONG NAME: Reference  -->
 <!ELEMENT xref          (%common-inline;)*        >
 <!ATTLIST xref
-             href       CDATA                            #IMPLIED
-             format     CDATA                            #IMPLIED
-             scope      (local | peer | external)        #IMPLIED
+             %reference-content;
              %localization;
              %variable-links;
              outputclass  CDATA          #IMPLIED
@@ -189,9 +191,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!ATTLIST keydef
               %localization;
               %filters;
-              href
-                        CDATA
-                                  #IMPLIED
+              %reference-content;
               keys
                         CDATA
                                   #REQUIRED

--- a/org.oasis.xdita/dtd/map.mod
+++ b/org.oasis.xdita/dtd/map.mod
@@ -36,11 +36,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!--    13 Jun 2017  CE: Added XDITA constraint token              -->
 <!--    13 Jun 2017  CE: Made map ID optional                      -->
 <!--    13 Jun 2017  CE: Added props to <keydef>                   -->
-<!--    14 Jun 2017  CE: Added <image>, <alt>, and <xref> to <ph>  -->
-<!--    14 Jun 2017  CE: Added @format and @scope to elements with -->
-<!--                     @href                                     -->
-<!--    14 Jun 2017  CE: Added localization attributes to elements -->
-<!--                     that might include content                -->
+<!--    14 Jun 2017  CE: Added <image>, <xref> to <ph>; add <alt>  -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->
 <!--                    DOMAINS ATTRIBUTE OVERRIDE                 -->
@@ -63,7 +59,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!-- ============================================================= -->
 
 <!ENTITY % common-inline  "#PCDATA|%ph;|image|%data;">
-<!ENTITY % all-inline  "#PCDATA|%ph;|alt|image|xref|%data;">
+<!ENTITY % all-inline  "#PCDATA|%ph;|image|xref|%data;">
 
 
 <!--common attributes-->
@@ -95,7 +91,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!--                    LONG NAME: Map  -->
 <!ELEMENT map		(topicmeta?, (topicref | keydef)*)  >
 <!ATTLIST map
-              id       ID          #IMPLIED
              xmlns:ditaarch CDATA #FIXED "http://dita.oasis-open.org/architecture/2005/"
 	     ditaarch:DITAArchVersion CDATA "1.3"
              domains    CDATA                    "&xdita-constraint; &included-domains;"
@@ -106,7 +101,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!--                    LONG NAME: Metadata-->
 <!ELEMENT topicmeta     (navtitle?, linktext?, data*) >
 <!ATTLIST topicmeta
-             %localization;
              class CDATA "- map/topicmeta ">
 
 <!--                    LONG NAME: Navigation title -->
@@ -127,10 +121,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
              name       CDATA                            #IMPLIED
              value      CDATA                            #IMPLIED
              href       CDATA                            #IMPLIED
-             format     CDATA                            #IMPLIED
-             scope      (local | peer | external)        #IMPLIED
              %variable-content;
-             %localization;
              outputclass  CDATA          #IMPLIED
              class CDATA "- topic/data ">
 
@@ -145,8 +136,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!ELEMENT image             (alt?)        >
 <!ATTLIST image
              href       CDATA                            #IMPLIED
-             format     CDATA                            #IMPLIED
-             scope      (local | peer | external)        #IMPLIED
              height     NMTOKEN                          #IMPLIED
              width      NMTOKEN                          #IMPLIED
              %localization;
@@ -156,7 +145,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
              
              
 <!--                    LONG NAME: Alternative content  -->
-<!ELEMENT alt           (#PCDATA|%ph;|xref|%data;)*        >
+<!ELEMENT alt           (#PCDATA|%ph;|%data;)*        >
 <!ATTLIST alt
              %localization;
              %variable-content;
@@ -182,7 +171,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
              locktitle CDATA      			 #FIXED 'yes'
 	           %reuse;
              %filters;
-             %localization;
              %reference-content;
 	           %control-variables;
              %variable-links;
@@ -192,7 +180,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!ELEMENT keydef	(topicmeta?, data*)        >
 <!ATTLIST keydef
               %filters;
-              %localization;
               href
                         CDATA
                                   #IMPLIED

--- a/org.oasis.xdita/dtd/map.mod
+++ b/org.oasis.xdita/dtd/map.mod
@@ -95,6 +95,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 	         ditaarch:DITAArchVersion CDATA "1.3"
              domains    CDATA                    "&xdita-constraint; &included-domains;"
              %localization;
+             outputclass  CDATA          #IMPLIED
              class CDATA "- map/map ">
 
 
@@ -108,12 +109,14 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!ELEMENT navtitle (#PCDATA|%ph;)* >
 <!ATTLIST navtitle
              %localization;
+             outputclass  CDATA          #IMPLIED
              class CDATA "- topic/navtitle ">
 
 <!--                    LONG NAME: Link text-->
 <!ELEMENT linktext     (#PCDATA | %ph;)* >
 <!ATTLIST linktext
-            %localization;
+             %localization;
+             outputclass  CDATA          #IMPLIED
              class CDATA "- map/linktext ">
 
 <!--                    LONG NAME: Data  -->
@@ -132,6 +135,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!ATTLIST ph
              %localization;
              %variable-content;
+             outputclass  CDATA          #IMPLIED
              class CDATA "- topic/ph ">
              
 <!--                    LONG NAME: Image  -->
@@ -177,6 +181,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
              %reference-content;
 	         %control-variables;
              %variable-links;
+             outputclass  CDATA          #IMPLIED
              class CDATA "- map/topicref ">
 
 <!--                    LONG NAME: Key Definition  -->
@@ -192,5 +197,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
                                   #REQUIRED
               processing-role
                         CDATA       #FIXED      'resource-only'
+              outputclass  CDATA          #IMPLIED
               class CDATA "+ map/topicref mapgroup-d/keydef "
 >

--- a/org.oasis.xdita/dtd/map.mod
+++ b/org.oasis.xdita/dtd/map.mod
@@ -92,7 +92,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!ELEMENT map		(topicmeta?, (topicref | keydef)*)  >
 <!ATTLIST map
              xmlns:ditaarch CDATA #FIXED "http://dita.oasis-open.org/architecture/2005/"
-	     ditaarch:DITAArchVersion CDATA "1.3"
+	         ditaarch:DITAArchVersion CDATA "1.3"
              domains    CDATA                    "&xdita-constraint; &included-domains;"
              %localization;
              class CDATA "- map/map ">
@@ -101,6 +101,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!--                    LONG NAME: Metadata-->
 <!ELEMENT topicmeta     (navtitle?, linktext?, data*) >
 <!ATTLIST topicmeta
+             %localization;
              class CDATA "- map/topicmeta ">
 
 <!--                    LONG NAME: Navigation title -->
@@ -118,6 +119,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!--                    LONG NAME: Data  -->
 <!ELEMENT data             (#PCDATA|%data;)*        >
 <!ATTLIST data
+             %localization;
              name       CDATA                            #IMPLIED
              value      CDATA                            #IMPLIED
              href       CDATA                            #IMPLIED
@@ -168,17 +170,19 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Map//EN"
 <!--                    LONG NAME: Topic or Map Reference  -->
 <!ELEMENT topicref	(topicmeta?, topicref*)        >
 <!ATTLIST topicref
+             %localization;
              locktitle CDATA      			 #FIXED 'yes'
-	           %reuse;
+	         %reuse;
              %filters;
              %reference-content;
-	           %control-variables;
+	         %control-variables;
              %variable-links;
              class CDATA "- map/topicref ">
 
 <!--                    LONG NAME: Key Definition  -->
 <!ELEMENT keydef	(topicmeta?, data*)        >
 <!ATTLIST keydef
+              %localization;
               %filters;
               href
                         CDATA

--- a/org.oasis.xdita/dtd/topic.mod
+++ b/org.oasis.xdita/dtd/topic.mod
@@ -122,7 +122,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!ATTLIST topic
              id       ID          #REQUIRED
              xmlns:ditaarch CDATA #FIXED "http://dita.oasis-open.org/architecture/2005/"
-	           ditaarch:DITAArchVersion CDATA "1.3"
+	         ditaarch:DITAArchVersion CDATA "1.3"
              domains CDATA "&xdita-constraint; &included-domains;"
              outputclass  CDATA    #IMPLIED
              %localization;
@@ -145,6 +145,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Prolog-->
 <!ELEMENT prolog (%data;)* >
 <!ATTLIST prolog
+             %localization;
              outputclass  CDATA          #IMPLIED
              class CDATA "- topic/prolog ">
 
@@ -329,6 +330,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Data  -->
 <!ELEMENT data             (#PCDATA|%data;)*        >
 <!ATTLIST data
+             %localization;
              name       CDATA                            #IMPLIED
              value      CDATA                            #IMPLIED
              href       CDATA                            #IMPLIED
@@ -351,6 +353,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Audio -->
 <!ELEMENT audio (fallback?, controls?, source*, track*)        >
 <!ATTLIST audio
+             %localization;
              %filters;
              %reuse;
              outputclass  CDATA          #IMPLIED
@@ -359,6 +362,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Video -->
 <!ELEMENT video (fallback?, controls?, poster?, source*, track*)        >
 <!ATTLIST video
+             %localization;
              %filters;
              %reuse;
              outputclass  CDATA          #IMPLIED
@@ -377,6 +381,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Display controls  -->
 <!ELEMENT controls 	EMPTY        >
 <!ATTLIST controls
+             %localization;
              name       CDATA   			#FIXED "controls"
              outputclass  CDATA          #IMPLIED
              class CDATA "+ topic/param h5m-d/controls ">
@@ -385,6 +390,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Poster image  -->
 <!ELEMENT poster		EMPTY        >
 <!ATTLIST poster
+             %localization;
              name       CDATA         #FIXED "poster"
              value      CDATA         #IMPLIED
              outputclass  CDATA          #IMPLIED
@@ -393,6 +399,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Source  -->
 <!ELEMENT source		EMPTY        >
 <!ATTLIST source
+             %localization;
              name       CDATA           #FIXED "source"
              value      CDATA           #IMPLIED
              outputclass  CDATA          #IMPLIED
@@ -401,6 +408,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Track for captions  -->
 <!ELEMENT track		EMPTY        >
 <!ATTLIST track
+             %localization;
              name       CDATA           #FIXED "track"
              value      CDATA           #IMPLIED
              outputclass  CDATA          #IMPLIED

--- a/org.oasis.xdita/dtd/topic.mod
+++ b/org.oasis.xdita/dtd/topic.mod
@@ -146,7 +146,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!ELEMENT prolog (%data;)* >
 <!ATTLIST prolog
              %localization;
-             outputclass  CDATA          #IMPLIED
              class CDATA "- topic/prolog ">
 
 

--- a/org.oasis.xdita/dtd/topic.mod
+++ b/org.oasis.xdita/dtd/topic.mod
@@ -54,6 +54,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--    13 Jun 2017  CE: Modified <stentry>, <strow>, <dlentry>,   -->
 <!--                     and <li> to allow one-or-more             -->
 <!--    14 Jun 2017  CE: Removed <fn> from <body>                  -->
+<!--    14 Jun 2017 RDA: Corrected use of @outputclass             -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->
 <!--                    DOMAINS ATTRIBUTE OVERRIDE                 -->
@@ -93,6 +94,10 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!ENTITY % reuse
             'id      NMTOKEN                            #IMPLIED
              conref  CDATA                              #IMPLIED  ' >
+<!ENTITY % reference-content
+            'href      CDATA                            #IMPLIED
+             format    CDATA                            #IMPLIED
+             scope     (local | peer | external)        #IMPLIED '>
 <!-- %fn-reuse; used for <fn> only, so you can remove this if you want -->
 <!ENTITY % fn-reuse
             'conref  CDATA                              #IMPLIED  ' >
@@ -310,7 +315,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Image  -->
 <!ELEMENT image             (alt?)        >
 <!ATTLIST image
-             href       CDATA                            #IMPLIED
+             %reference-content;
              height     NMTOKEN                          #IMPLIED
              width      NMTOKEN                          #IMPLIED
              %localization;
@@ -332,7 +337,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
              %localization;
              name       CDATA                            #IMPLIED
              value      CDATA                            #IMPLIED
-             href       CDATA                            #IMPLIED
+             %reference-content;
              %variable-content;
              outputclass  CDATA          #IMPLIED
              class CDATA "- topic/data ">
@@ -340,9 +345,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Reference  -->
 <!ELEMENT xref          (%common-inline;)*        >
 <!ATTLIST xref
-             href       CDATA                            #IMPLIED
-             format     CDATA                            #IMPLIED
-             scope      (local | peer | external)        #IMPLIED
+             %reference-content;
              %localization;
              %variable-links;
              outputclass  CDATA          #IMPLIED

--- a/org.oasis.xdita/dtd/topic.mod
+++ b/org.oasis.xdita/dtd/topic.mod
@@ -54,10 +54,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--    13 Jun 2017  CE: Modified <stentry>, <strow>, <dlentry>,   -->
 <!--                     and <li> to allow one-or-more             -->
 <!--    14 Jun 2017  CE: Removed <fn> from <body>                  -->
-<!--    14 Jun 2017  CE: Added @format and @scope to elements with -->
-<!--                     @href                                     -->
-<!--    14 Jun 2017  CE: Added localization attributes to elements -->
-<!--                     that might include content                -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->
 <!--                    DOMAINS ATTRIBUTE OVERRIDE                 -->
@@ -83,7 +79,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!-- common content models -->
 
 <!ENTITY % common-inline  "#PCDATA|%ph;|image|%data;">
-<!ENTITY % all-inline  "#PCDATA|%ph;|alt|image|xref|%data;">
+<!ENTITY % all-inline  "#PCDATA|%ph;|image|xref|%data;">
 <!ENTITY % simple-blocks  "p|ul|ol|dl|pre|audio|video|fn|note|%data;">
 <!ENTITY % fn-blocks  "p|ul|ol|dl|%data;">
 <!ENTITY % all-blocks  "p|ul|ol|dl|pre|audio|video|simpletable|fig|fn|note|%data;">
@@ -149,7 +145,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--                    LONG NAME: Prolog-->
 <!ELEMENT prolog (%data;)* >
 <!ATTLIST prolog
-             %localization;
              outputclass  CDATA          #IMPLIED
              class CDATA "- topic/prolog ">
 
@@ -316,8 +311,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!ELEMENT image             (alt?)        >
 <!ATTLIST image
              href       CDATA                            #IMPLIED
-             format     CDATA                            #IMPLIED
-             scope      (local | peer | external)        #IMPLIED
              height     NMTOKEN                          #IMPLIED
              width      NMTOKEN                          #IMPLIED
              %localization;
@@ -326,7 +319,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
              class CDATA "- topic/image ">
 
 <!--                    LONG NAME: Alternative content  -->
-<!ELEMENT alt           (#PCDATA|%ph;|xref|%data;)*        >
+<!ELEMENT alt           (#PCDATA|%ph;|%data;)*        >
 <!ATTLIST alt
              %localization;
              %variable-content;
@@ -339,10 +332,7 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
              name       CDATA                            #IMPLIED
              value      CDATA                            #IMPLIED
              href       CDATA                            #IMPLIED
-             format     CDATA                            #IMPLIED
-             scope      (local | peer | external)        #IMPLIED
              %variable-content;
-             %localization;
              outputclass  CDATA          #IMPLIED
              class CDATA "- topic/data ">
 
@@ -363,7 +353,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!ATTLIST audio
              %filters;
              %reuse;
-             %localization;
              outputclass  CDATA          #IMPLIED
              class CDATA "+ topic/object h5m-d/audio ">
 
@@ -372,7 +361,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!ATTLIST video
              %filters;
              %reuse;
-             %localization;
              outputclass  CDATA          #IMPLIED
              height     NMTOKEN                          #IMPLIED
              width      NMTOKEN                          #IMPLIED
@@ -399,7 +387,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!ATTLIST poster
              name       CDATA         #FIXED "poster"
              value      CDATA         #IMPLIED
-             %localization;
              outputclass  CDATA          #IMPLIED
              class CDATA "+ topic/param h5m-d/poster ">
 
@@ -408,7 +395,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!ATTLIST source
              name       CDATA           #FIXED "source"
              value      CDATA           #IMPLIED
-             %localization;
              outputclass  CDATA          #IMPLIED
              class CDATA "+ topic/param h5m-d/source ">
 
@@ -417,7 +403,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!ATTLIST track
              name       CDATA           #FIXED "track"
              value      CDATA           #IMPLIED
-             %localization;
              outputclass  CDATA          #IMPLIED
              class CDATA "+ topic/param h5m-d/track ">
 

--- a/org.oasis.xdita/dtd/topic.mod
+++ b/org.oasis.xdita/dtd/topic.mod
@@ -54,7 +54,9 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 <!--    13 Jun 2017  CE: Modified <stentry>, <strow>, <dlentry>,   -->
 <!--                     and <li> to allow one-or-more             -->
 <!--    14 Jun 2017  CE: Removed <fn> from <body>                  -->
-<!--    14 Jun 2017 RDA: Corrected use of @outputclass             -->
+<!--    14 Jun 2017 RDA: Corrected use of @outputclass,            -->
+<!--                     make localization attributes universal,   -->
+<!--                     add scope/format where needed             -->
 <!-- ============================================================= -->
 <!-- ============================================================= -->
 <!--                    DOMAINS ATTRIBUTE OVERRIDE                 -->
@@ -113,10 +115,6 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
              "scale ( 50|60|70|80|90|100|110|120|140|160|180|200 ) #IMPLIED
               frame ( all|bottom|none|sides|top|topbot )           #IMPLIED
               expanse ( column|page|spread|textline )              #IMPLIED">
-<!ENTITY % fig.attributes
-             "%display-atts;
-              %localization;
-              outputclass CDATA #IMPLIED">
 
 <!-- ============================================================= -->
 <!--                    ELEMENT DECLARATIONS                       -->
@@ -293,7 +291,9 @@ PUBLIC "-//OASIS//ELEMENTS XDITA Topic//EN"
 
 <!ELEMENT fig   (title?, desc?, (%fig-blocks;|image|xref)*)    >
 <!ATTLIST fig
-             %fig.attributes;
+             %display-atts;
+             %localization;
+             outputclass CDATA #IMPLIED
              class CDATA "- topic/fig " >
 
 


### PR DESCRIPTION
- Fix updates for `<alt>` that added it outside image model
- Make localization attributes universal
- Add outputclass where missing, remove where not legal
- Add scope/format to elements that don't have it (helped by only using the `reference-content` entity)
- Moved definition of figure attributes from `fig.attributes` into figure -- this brings it inline with all other elements, and the entity was not used anywhere else
- Added mapgroup domain token to `map/@domains`